### PR TITLE
Add pylint requirement for use in project

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,9 @@
+astroid==1.6.1
 Django==1.11
+isort==4.3.3
+lazy-object-proxy==1.3.1
+mccabe==0.6.1
+pylint==1.8.2
 pytz==2017.3
+six==1.11.0
+wrapt==1.10.11


### PR DESCRIPTION
This change will install the pylint CLI for use when checking for style validation in the repo.
This should be used to maintain consistent style and good practice across all our changes.
I'm only adding the dependency right now, and it can be used across PR's; the eventual goal is that it becomes a mandatory step within our CI checks.
Future PR's will need to ensure passing style for the linter to be merged.