### PR TITLE
Dev DB Tools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,16 @@
 astroid==1.6.1
 Django==1.11
+django-filter==1.1.0
+django-seed==0.1.8
+Faker==0.8.11
 isort==4.3.3
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
 pylint==1.8.2
 pylint-django==0.9.0
 pylint-plugin-utils==0.2.6
+python-dateutil==2.6.1
 pytz==2017.3
 six==1.11.0
+text-unidecode==1.2
 wrapt==1.10.11
-django-filter==1.1.0

--- a/webapp/geek_text/management/commands/clear_db.py
+++ b/webapp/geek_text/management/commands/clear_db.py
@@ -1,0 +1,24 @@
+
+from django.core.management.base import BaseCommand
+
+from django_seed import Seed
+
+from django.contrib.auth.models import User
+from book_details.models import Book, Author, Publisher, Genre
+from reviews.models import Review
+
+class Command(BaseCommand):
+    help = 'Clears all models from the local DB'
+
+    def handle(self, *args, **options):
+        # Reviews
+        Review.objects.all().delete()
+
+        # Book Details
+        Book.objects.all().delete()
+        Author.objects.all().delete()
+        Publisher.objects.all().delete()
+        Genre.objects.all().delete()
+
+        # User
+        User.objects.all().delete()

--- a/webapp/geek_text/management/commands/seed_db.py
+++ b/webapp/geek_text/management/commands/seed_db.py
@@ -1,0 +1,27 @@
+from django.core.management.base import BaseCommand
+
+from django_seed import Seed
+
+from django.contrib.auth.models import User
+from book_details.models import Book, Author, Publisher, Genre
+from reviews.models import Review
+
+class Command(BaseCommand):
+    help = 'Seeds the local DB by adding model instances'
+
+    def handle(self, *args, **options):
+        seeder = Seed.seeder()
+
+        # User
+        seeder.add_entity(User, 15)
+
+        # Book Details
+        seeder.add_entity(Author, 15)
+        seeder.add_entity(Publisher, 15)
+        seeder.add_entity(Genre, 15)
+        seeder.add_entity(Book, 15)
+
+        # Reviews
+        seeder.add_entity(Review, 15)
+
+        seeder.execute()

--- a/webapp/geek_text/settings.py
+++ b/webapp/geek_text/settings.py
@@ -37,10 +37,11 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'book_details',
-    'reviews',
     'geek_text',
+    'django_seed',
+    'book_details',
     'browse',
+    'reviews',
 ]
 
 MIDDLEWARE = [

--- a/webapp/geek_text/settings.py
+++ b/webapp/geek_text/settings.py
@@ -50,7 +50,6 @@ INSTALLED_APPS = [
     'book_details',
     'browse',
     'reviews',
-    'reviews',
     'geek_text',
 ]
 

--- a/webapp/reviews/models.py
+++ b/webapp/reviews/models.py
@@ -2,12 +2,15 @@ from django.conf import settings
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
+# Using direct User model due to issues with Seeder
+from django.contrib.auth.models import User
+
 class Review(models.Model):
     book = models.ForeignKey(
         'book_details.Book',
         related_name='reviews')
     user = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
+        User,
         related_name='reviews')
     anonymous = models.BooleanField(
         'Whether or not the comment was posted anonymously')


### PR DESCRIPTION
This PR adds two commands to the `manage.py` script:

- `seed_db`: Add 15 of each model type to the database filled with random data
- `clear_db`: Remove every model instance in the database

I've added these as commands for convenience and because the native `seed` command provided by the added app ([django-seed](https://github.com/Brobin/django-seed)) does not really work all too well with Foreign Keys.

The current implementation is very simplistic, but I feel it satisfies our use cases entirely.